### PR TITLE
add multiprocessing and retry script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ Rights of use and distribution are granted under the terms of the GNU Affero Gen
 
 La Trobe University Library is grateful to [all who have contributed to this project](ACKNOWLEDGEMENTS.md).
 
+Ruth Lewis provided the instructions for export and import of Alma data.
+
 # Contact
 
 The maintainer of this repository is Hugh Rundle, who can be contacted at h.rundle@latrobe.edu.au
 
 # Description 
 
-This is a basic Python script for scraping book covers for Open Educational Resources for import into Ex Libris Alma.
+This is a set of basic Python scripts for scraping book covers for Open Educational Resources for import into Ex Libris Alma.
 
 The script takes an input file which should be an export from Alma converted to CSV format.
 
@@ -74,16 +76,23 @@ FETCH FIRST 10000001 ROWS ONLY
 
 Then run the script from a terminal/PowerShell:
 
-`uv run oer_cover_scraper.py inputfilename outputfilename` 
+```sh
+uv run oer_covers.py inputfilename outputfilename
+```
 
 _inputfilename_ should be your file exported from Alma and converted to csv.
-_outputfilename_ should be a new `.xslx` filename that will contain the output.
+_outputfilename_ should be a new `.xlsx` filename that will contain the output.
 
 e.g.
 
 ```sh
-uv run oer_cover_scraper.py alma_export.csv output_file.xslx
+uv run oer_covers.py alma_export.csv output_file.xlsx
 ```
+
+You should end up with an Excel file with two tabs:
+
+* `covers_for_upload` is for importing back into Alma (see below)
+* `errors` will contain a list of any resources where some kind of HTTP or connection error occured. This may indicate that the URL you have in Alma is out of date, broken, or otherwise needs attention.  
 
 ## Importing the output file
 
@@ -97,24 +106,38 @@ In Alma:
 4. Select the spreadsheet as the file to load.
 5. Click Submit.
 
-The job will add the 956 field to matching bibliographic records. This may take a few hours to show up in your discovery interface.
+The job will add the URL for the cover image to the 956 field in matching bibliographic records. This may take a few hours to show up in your discovery interface.
 
 ## Logging
 
-The script will spit out errors including HTTP errors. You might like to send them to a log file rather than your terminal:
+The script will spit out any additional errors. You might like to send them to a log file rather than your terminal:
 
 ```sh
-uv run oer_cover_scraper.py source_file.csv output_file.xslx >> logfile.txt
+uv run oer_covers.py source_file.csv output_file.xlsx >> logfile.txt
 ```
+
+## Retrying errors
+
+You may get errors for some links. These will be saved in the second `errors` tab in your output file.
+
+You may wish to attempt these again, especially if you got a lot of `429` "Too many requests" errors. To do this, you can use the `retry_errors.py` file. Save the `errors` tab as a new csv file, then run `retry_errors.py` with this new CSV file as your input:
+
+```sh
+uv run retry_errors.py errors.csv output_file.xlsx >> logfile.txt
+```
+
+This script deliberately runs slower than `oer_covers.py` (to avoid `429` errors, which may be what you got originally) and expects your csv file to be structured like the `errors` tab in an output file. To upload the output from this run, follow the same procedure outlined in _Importing the output file_, above.
 
 ## Image sources
 
 Currently this will only work for books from:
 
-* latrobe.edu.au
-* library.oapen.org
-* milneopentextbooks.org
-* oercollective.caul.edu.au
+* latrobe.edu.au (La Trobe eBureau)
+* library.oapen.org (OAPEN)
+* milneopentextbooks.org & milnepublishing.geneseo.edu (Milne Library Open Publishing, SUNY)
+* oercollective.caul.edu.au (CAUL OER Collective)
+* open.umn.edu (Open Textbook Library)
+* jcu.pressbooks.pub (James Cook University)
 
 You can add your own or log an Issue with a request for a new source. 
-Note that Rice University inexplicably reserves all copyrights on OpenStax book covers, so they cannot be used.
+Note that Rice University inexplicably reserves all rights on OpenStax book covers, so they cannot be used, even though the rest of the book is CC licensed.

--- a/retry_errors.py
+++ b/retry_errors.py
@@ -1,6 +1,5 @@
 from bs4 import BeautifulSoup
 import csv
-from multiprocessing import Pool
 import requests
 import sys
 import time
@@ -12,20 +11,15 @@ def get_cover_image(row):
     """find the URL of the cover image and add it to a row in the export file"""
 
     # for each link, use Beautiful Soup to find the image URL
-    for key in ["Portfolio Static URL", "Portfolio Static URL (override)", "Portfolio Parser Parameters"]:
-        if row[key]:
-            raw_url = row[key][5:].strip() # remove 'jkey=' or 'bkey=' and any spaces on either end
-            url = raw_url.split(" ")[0] # remove anything after the URL e.g. providerid from parser parameters
-        else:
-            # it's empty
-            continue
+    if row["URL"]:
+        raw_url = row["URL"].strip() # remove any spaces on either end
+        url = raw_url.split(" ")[0] # remove anything after the URL e.g. providerid from parser parameters
 
         try:
 
             if "open.umn.edu" in url: # OTL is rate-limited, avoid 429 errors by slowing down
                 time.sleep(1) 
-
-            headers = {"user-agent": "OER-Covers-Fetcher/0.0.3"} # don't use a generic user agent
+            headers = {"user-agent": "OER-Covers-Retry/0.0.1"} # don't use a generic user agent
             page = requests.get(url, headers=headers)
             page.raise_for_status() # raise the error immediately if we didn't get a successful page load
             soup = BeautifulSoup(page.content, "html.parser")
@@ -43,9 +37,9 @@ def get_cover_image(row):
                 if len(sources) > 0:
                     source = sources[0]
                 else:
-                    continue 
+                    return 
 
-            elif "milneopentextbooks.org" in url: # Milne Library Publishing at SUNY Geneseo
+            elif "milneopentextbooks.org" in url: #Milne Library Publishing at SUNY Geneseo
                 figures = soup.find_all("figure")
                 for fig in figures:
                     if fig.find("img") and "wp-content/uploads" in fig.find("img")["src"]:
@@ -56,26 +50,27 @@ def get_cover_image(row):
                 raw_source = soup.find("img", class_="img-thumbnail")["src"]
                 source = f"https://library.oapen.org/{raw_source}"
 
+
             elif "open.umn.edu" in url: # Open Textbook Library
                 source = soup.find("div", id="cover").find("img")["src"]
+
                 if "placeholder" in source:
-                    continue # don't bother with the relative placeholder paths from OTL
+                    return # don't bother with the relative placeholder paths from OTL
 
             elif "openstax.org" in url: # OpenStax
                 # openstax book covers are All Rights Reserved Rice University
                 # so cannot be used
-                continue
+                return
 
             else:
                 # we don't know about that source - log an issue so it can be added :)
                 p = urlparse(url)
                 print(f"Cannot parse from this OER source: {p.hostname}")
-                continue
-        
-            # add the image url to the entry for that book
-            data = (str(row["MMS Id"]), source, "Thumbnail", "local", row["Title"])
-            return {"type": "cover", "data": data}
+                return
 
+            # add the image url to the entry for that book
+            data = (str(row["MMS Id"]), source, "Thumbnail", "local", str(row["MMS Id"]))
+            return {"type": "cover", "data": data}
 
         except requests.exceptions.HTTPError:
 
@@ -94,9 +89,12 @@ def get_cover_image(row):
         except Exception as e:
 
             # Something else went wrong
-            print(row["Title"], type(e), e)
-            continue
+            print(row["MMS Id"], type(e), e)
+            return
 
+    else:
+        # it's empty
+        return
 
 if __name__ == '__main__':
     """When the script is called..."""
@@ -110,22 +108,22 @@ if __name__ == '__main__':
     workbook = xlsxwriter.Workbook(output_file)
     
     worksheet = workbook.add_worksheet("covers_for_upload")
-    worksheet.write_row("A1", ("001","95642$u", "95642$3","95642$9","Title"))
+    worksheet.write_row("A1", ("001","95642$u", "95642$3","95642$9","MMS Id"))
 
     errors = workbook.add_worksheet("errors") 
-    errors.write_row("A1", (str("MMS Id"), "URL", "Error code")) 
+    errors.write_row("A1", ("MMS Id", "URL", "Error code")) 
 
     #  read csv of book URLs
     with open(source_file, "r") as csvfile:
         reader = csv.DictReader(csvfile)
 
-        pool = Pool(2) # uses only 2 processes. Too many and you will get rate limited    
         index = 2
         error_index = 2
 
-        # run get_cover_image() for each row, multi-threaded
-        for value in pool.map(get_cover_image, reader):
-                
+        # run get_cover_image() for each row, the slow way
+        # the most likely errors are 404 and 429
+        for row in reader:
+            value = get_cover_image(row)
             if value:
                 if value.get("type") == "error":
                     errors.write_row(f"A{error_index}", value["data"])
@@ -134,9 +132,4 @@ if __name__ == '__main__':
                     worksheet.write_row(f"A{index}", value["data"])
                     index += 1
 
-        # remember to close the multprocessing pool
-        pool.close() 
-        pool.join()
-
     workbook.close()
-    


### PR DESCRIPTION
Adds `multiprocessing` to make the script run faster. Also adds a `retry_errors.py` script to run through all the errors in a prior run and try again, without multiprocessing.

Improved error checking, time delay on OTL since it uses rate limiting, and various other tidying up.